### PR TITLE
Upgrading rubyzip to 1.0.0

### DIFF
--- a/lib/zippy.rb
+++ b/lib/zippy.rb
@@ -1,5 +1,5 @@
 #encoding: utf-8
-require 'zip/zip'
+require 'zip'
 
 class Zippy
 
@@ -120,7 +120,7 @@ class Zippy
 
 
   def zipfile
-    @zipfile ||= Zip::ZipFile.new(filename, true)
+    @zipfile ||= Zip::File.new(filename, true)
   end
 
 

--- a/spec/zippy_spec.rb
+++ b/spec/zippy_spec.rb
@@ -23,7 +23,7 @@ describe "An archive" do
 
   it "should have a zipfile attribute" do
     @zip.should respond_to('zipfile')
-    @zip.zipfile.should be_an_instance_of(Zip::ZipFile)
+    @zip.zipfile.should be_an_instance_of(Zip::File)
   end
 
   it "should yield self on initialize" do

--- a/zippy.gemspec
+++ b/zippy.gemspec
@@ -10,5 +10,5 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
   s.files         = ["lib/zippy.rb", "README", "LICENSE"]
   s.require_paths = ['lib']
-  s.add_dependency("rubyzip", [">= 0.9.1"])
+  s.add_dependency("rubyzip", [">= 1.0.0"])
 end


### PR DESCRIPTION
Zippy does not work with rubyzip 1.0.0 so it's either this or changing the dependency to < 1.0.0
